### PR TITLE
fix for cloning https instead of git

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -4,7 +4,7 @@
 
     mkdir -p ~/Library/Application\ Support/TextMate/Bundles/
     cd ~/Library/Application\ Support/TextMate/Bundles/
-    git clone https://github.com/gregory-m/ejs-tmbundle.git EJS.tmbundle
+    git clone git://github.com/gregory-m/ejs-tmbundle.git EJS.tmbundle
     osascript -e 'tell app "TextMate" to reload bundles'
 
 ## License


### PR DESCRIPTION
error: The requested URL returned error: 403 while accessing https://github.com/gregory-m/ejs-tmbundle.git/info/refs
fatal: HTTP request failed
